### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/324/95/85632495.geojson
+++ b/data/856/324/95/85632495.geojson
@@ -475,6 +475,10 @@
     ],
     "wof:country":"CC",
     "wof:country_alpha3":"CCK",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ffa4573273e9def056bc2a3bfac6d87b",
     "wof:hierarchy":[
         {
@@ -490,7 +494,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1561844819,
+    "wof:lastmodified":1582345580,
     "wof:name":"Australian Indian Ocean Territories",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.