### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/117/574/729/5/1175747295.geojson
+++ b/data/117/574/729/5/1175747295.geojson
@@ -259,6 +259,9 @@
         "\u30b3\u30b3\u30b9\u8af8\u5cf6",
         "\u30b3\u30b3\u30b9[\u30ad\u30fc\u30ea\u30f3\u30b0]\u8af8\u5cf6"
     ],
+    "name:kaa_x_preferred":[
+        "Kokosl\u0131 atawlar\u0131"
+    ],
     "name:kan_x_preferred":[
         "\u0c95\u0cca\u0c95\u0cca\u0cb8\u0ccd \u0ca6\u0ccd\u0cb5\u0cc0\u0caa\u0c97\u0cb3\u0cc1"
     ],
@@ -315,7 +318,11 @@
         "Cocos (Keeling) Islands"
     ],
     "name:mlt_x_variant":[
-        "G\u017cejjer Kokos"
+        "G\u017cejjer Kokos",
+        "G\u017cejjer Cocos"
+    ],
+    "name:mri_x_preferred":[
+        "nga Moutere o Cocos"
     ],
     "name:msa_x_preferred":[
         "Cocos [Keeling] Islands"
@@ -325,6 +332,9 @@
     ],
     "name:mya_x_preferred":[
         "\u1000\u102d\u102f\u1000\u102d\u102f\u1038 \u1000\u103b\u103d\u1014\u103a\u1038\u1005\u102f"
+    ],
+    "name:mya_x_variant":[
+        "\u1000\u102d\u102f\u1000\u102d\u102f\u1037\u1005\u103a \u1000\u103b\u103d\u1014\u103a\u1038\u1019\u103b\u102c\u1038"
     ],
     "name:nep_x_preferred":[
         "\u0915\u094b\u0915\u094b\u0938 \u091f\u093e\u092a\u0941"
@@ -354,6 +364,9 @@
     ],
     "name:ori_x_preferred":[
         "\u0b15\u0b4b\u0b15\u0b4b\u0b38\u0b4d \u0b06\u0b07\u0b38\u0b32\u0b4d\u0b5f\u0b3e\u0b23\u0b4d\u0b21"
+    ],
+    "name:pih_x_preferred":[
+        "Koekos / Kiiling Ailen"
     ],
     "name:pnb_x_preferred":[
         "\u062c\u0632\u0627\u0626\u0631 \u06a9\u0648\u06a9\u0648\u0633"
@@ -388,6 +401,9 @@
     ],
     "name:scn_x_preferred":[
         "\u00ccsuli Cocos"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u1030\u1087\u1075\u102f\u107c\u103a \u1076\u1030\u101d\u103a\u1038\u1075\u1010\u103a\u1089"
     ],
     "name:sin_x_preferred":[
         "\u0d9a\u0ddc\u0d9a\u0ddd\u0dc3\u0dca \u0daf\u0dd6\u0db4\u0dad\u0dca"
@@ -439,6 +455,9 @@
     "name:tel_x_preferred":[
         "\u0c15\u0c4b\u0c15\u0c4b\u0c38\u0c4d \u0c26\u0c40\u0c35\u0c41\u0c32\u0c41"
     ],
+    "name:tgk_x_preferred":[
+        "\u04b6\u0430\u0437\u0438\u0440\u0430\u04b3\u043e\u0438 \u041a\u0438\u043b\u0438\u043d\u0433"
+    ],
     "name:tgl_x_preferred":[
         "Kapuluang Cocos"
     ],
@@ -475,6 +494,9 @@
     ],
     "name:urd_x_variant":[
         "\u062c\u0632\u0627\u0626\u0631 \u06a9\u0648\u06a9\u0648\u0633"
+    ],
+    "name:uzb_x_preferred":[
+        "Kakos orollari"
     ],
     "name:vie_x_preferred":[
         "Qu\u1ea7n \u0111\u1ea3o Cocos"
@@ -745,7 +767,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827486,
+    "wof:lastmodified":1690865768,
     "wof:name":"Australian Indian Ocean Territories",
     "wof:parent_id":102191569,
     "wof:placetype":"dependency",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.