### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/117/574/729/5/1175747295.geojson
+++ b/data/117/574/729/5/1175747295.geojson
@@ -18,12 +18,12 @@
     "label:eng_x_preferred_shortcode":[
         "CC"
     ],
-    "lbl:latitude":-12.002,
-    "lbl:longitude":96.8785,
+    "lbl:latitude":-10.489873,
+    "lbl:longitude":105.64527,
     "lbl:max_zoom":8.0,
     "lbl:min_zoom":4.0,
-    "mps:latitude":-12.002,
-    "mps:longitude":96.8785,
+    "mps:latitude":-10.489873,
+    "mps:longitude":105.64527,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:max_zoom":9.5,
@@ -767,7 +767,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690865768,
+    "wof:lastmodified":1694320299,
     "wof:name":"Australian Indian Ocean Territories",
     "wof:parent_id":102191569,
     "wof:placetype":"dependency",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.